### PR TITLE
Add multi-agent review automation toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,3 +273,14 @@ MIT
 ---
 
 Built with ❤️ for better healthcare accessibility
+
+
+## 🤖 Multi-agent Review Automation
+
+Run the built-in Python toolkit to generate an architecture-aware review report:
+
+```bash
+python -m multi_agent_review.cli --root $(pwd) --output review-report.md
+```
+
+The orchestrator walks the backend, frontend, and database workspaces, runs specialist agents, and writes a Markdown summary to `review-report.md`.

--- a/multi_agent_review/__init__.py
+++ b/multi_agent_review/__init__.py
@@ -1,0 +1,5 @@
+"""Multi-agent review toolkit for the telehealth codebase."""
+
+from .orchestrator import ReviewOrchestrator
+
+__all__ = ["ReviewOrchestrator"]

--- a/multi_agent_review/__main__.py
+++ b/multi_agent_review/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/multi_agent_review/agents/__init__.py
+++ b/multi_agent_review/agents/__init__.py
@@ -1,0 +1,23 @@
+"""Collection of review agents."""
+
+from .ai import AIConsultationAgent
+from .automation import AutomationQualityAgent
+from .backend import BackendReviewAgent
+from .cartographer import RepositoryCartographerAgent
+from .database import DatabaseIntegrityAgent
+from .frontend import FrontendExperienceAgent
+from .integration import IntegrationContractAgent
+from .security import SecurityComplianceAgent
+from .synthesis import SynthesisAgent
+
+__all__ = [
+    "AIConsultationAgent",
+    "AutomationQualityAgent",
+    "BackendReviewAgent",
+    "RepositoryCartographerAgent",
+    "DatabaseIntegrityAgent",
+    "FrontendExperienceAgent",
+    "IntegrationContractAgent",
+    "SecurityComplianceAgent",
+    "SynthesisAgent",
+]

--- a/multi_agent_review/agents/ai.py
+++ b/multi_agent_review/agents/ai.py
@@ -1,0 +1,62 @@
+"""AI consultation specialist agent."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..models import AgentResult
+from ..repository import RepositoryContext
+from .base import BaseAgent
+
+
+class AIConsultationAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="AI Consultation Specialist",
+            description="Reviews the OpenAI-backed service for guardrails and safety gaps.",
+        )
+
+    def run(self, context: RepositoryContext, state) -> AgentResult:
+        result = AgentResult()
+        service_file = context.backend_src / "services" / "ai-consultation.service.js"
+        content = context.maybe_read_text(service_file)
+        if not content:
+            return result
+
+        json_parse_match = re.search(r"JSON\.parse\(response\.choices\[0\]\.message\.content\)", content)
+        if json_parse_match:
+            line = content.count("\n", 0, json_parse_match.start()) + 1
+            result.findings.append(
+                self.finding(
+                    title="LLM JSON output is trusted without schema validation",
+                    description=(
+                        "Wrap the parsed response in a schema validator (zod/io-ts) to reject malformed content "
+                        "before persisting clinical recommendations."
+                    ),
+                    severity="medium",
+                    file_path=str(service_file.relative_to(context.root)),
+                    line=line,
+                    tags=["ai", "safety"],
+                )
+            )
+
+        if "generatePatientMessage" in content and "disclaimer" not in content.lower():
+            marker = "Create a warm, professional message"
+            idx = content.find(marker)
+            line = content.count("\n", 0, idx) + 1 if idx != -1 else None
+            result.findings.append(
+                self.finding(
+                    title="Patient messaging prompt lacks compliance disclaimer",
+                    description=(
+                        "Add explicit instructions for medical disclaimers and clinician review when generating patient-facing "
+                        "messages so AI output never replaces licensed guidance."
+                    ),
+                    severity="medium",
+                    file_path=str(service_file.relative_to(context.root)),
+                    line=line,
+                    tags=["ai", "compliance"],
+                )
+            )
+
+        return result

--- a/multi_agent_review/agents/automation.py
+++ b/multi_agent_review/agents/automation.py
@@ -1,0 +1,62 @@
+"""Automation & quality agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from ..models import AgentResult
+from ..repository import RepositoryContext
+from .base import BaseAgent
+
+
+class AutomationQualityAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Automation & Quality",
+            description="Summarizes available lint/test scripts and flags missing coverage.",
+        )
+
+    def run(self, context: RepositoryContext, state) -> AgentResult:
+        result = AgentResult()
+        workspaces = {
+            "backend": context.backend_path / "package.json",
+            "frontend": context.frontend_path / "package.json",
+        }
+        commands: Dict[str, List[str]] = {}
+
+        for name, package_path in workspaces.items():
+            package = context.maybe_read_text(package_path)
+            if not package:
+                continue
+            data = context.read_json(package_path)
+            scripts = data.get("scripts", {})
+            recommended = [cmd for cmd in ("lint", "test", "type-check") if cmd in scripts]
+            commands[name] = [f"npm run {cmd}" for cmd in recommended]
+
+            missing = [cmd for cmd in ("lint", "test") if cmd not in scripts]
+            if missing:
+                result.findings.append(
+                    self.finding(
+                        title=f"{name.title()} workspace missing automation script",
+                        description=(
+                            f"Add {' and '.join(missing)} scripts to `{name}/package.json` so CI can validate patches automatically."
+                        ),
+                        severity="low",
+                        file_path=str(package_path.relative_to(context.root)),
+                        tags=["automation"],
+                    )
+                )
+            else:
+                result.findings.append(
+                    self.finding(
+                        title=f"{name.title()} automation commands discovered",
+                        description=", ".join(f"npm run {cmd}" for cmd in recommended) or "No standard commands",
+                        severity="info",
+                        file_path=str(package_path.relative_to(context.root)),
+                        tags=["automation"],
+                    )
+                )
+
+        result.artifacts["commands"] = commands
+        return result

--- a/multi_agent_review/agents/backend.py
+++ b/multi_agent_review/agents/backend.py
@@ -1,0 +1,67 @@
+"""Backend API review agent."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+from ..models import AgentResult
+from ..repository import RepositoryContext
+from .base import BaseAgent
+
+
+class BackendReviewAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Backend API Reviewer",
+            description="Checks Express routes for missing authentication and unfinished implementations.",
+        )
+        self.auth_exempt_prefixes = {"/api/auth", "/webhooks"}
+
+    def run(self, context: RepositoryContext, state) -> AgentResult:
+        result = AgentResult()
+        for mount in context.backend_route_mounts():
+            route_file = Path(context.root / mount["file_path"])
+            content = context.read_text(route_file)
+
+            if not self._is_auth_protected(content) and not self._is_exempt(mount["base_path"]):
+                result.findings.append(
+                    self.finding(
+                        title="Route missing authentication guard",
+                        description=(
+                            f"The router mounted at `{mount['base_path']}` does not reference `requireAuth` or `requireRole`. "
+                            "Attach role-aware middleware so protected resources cannot be accessed anonymously."
+                        ),
+                        severity="high",
+                        file_path=mount["file_path"],
+                        tags=["auth", "backend"],
+                    )
+                )
+
+            for placeholder in self._find_placeholders(content):
+                result.findings.append(
+                    self.finding(
+                        title="Placeholder implementation in API route",
+                        description="Replace the placeholder response with production logic for file uploads and retrieval.",
+                        severity="medium",
+                        file_path=mount["file_path"],
+                        line=placeholder,
+                        tags=["todo", "backend"],
+                    )
+                )
+
+        return result
+
+    def _is_auth_protected(self, content: str) -> bool:
+        return any(token in content for token in ("requireAuth", "requireRole", "optionalAuth"))
+
+    def _is_exempt(self, base_path: str) -> bool:
+        return any(base_path.startswith(prefix) for prefix in self.auth_exempt_prefixes)
+
+    def _find_placeholders(self, content: str) -> List[int]:
+        matches = []
+        for match in re.finditer(r"implementation needed", content, re.IGNORECASE):
+            line = content.count("\n", 0, match.start()) + 1
+            matches.append(line)
+        return matches

--- a/multi_agent_review/agents/base.py
+++ b/multi_agent_review/agents/base.py
@@ -1,0 +1,57 @@
+"""Base classes for review agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from ..models import AgentResult, Finding, Severity, SharedState
+from ..repository import RepositoryContext
+
+
+@dataclass
+class BaseAgent:
+    name: str
+    description: str
+
+    def execute(self, context: RepositoryContext, state: SharedState) -> AgentResult:
+        result = self.run(context, state)
+        state.record(self.name, result)
+        return result
+
+    def run(self, context: RepositoryContext, state: SharedState) -> AgentResult:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def finding(
+        self,
+        title: str,
+        description: str,
+        *,
+        severity: Severity = "info",
+        file_path: Optional[str] = None,
+        line: Optional[int] = None,
+        tags: Optional[Iterable[str]] = None,
+    ) -> Finding:
+        return Finding(
+            agent=self.name,
+            title=title,
+            description=description,
+            severity=severity,
+            file_path=file_path,
+            line=line,
+            tags=list(tags) if tags else [],
+        )
+
+
+class CompositeAgent(BaseAgent):
+    """Agent that delegates to a collection of child agents."""
+
+    def __init__(self, name: str, description: str, children: List[BaseAgent]):
+        super().__init__(name=name, description=description)
+        self.children = children
+
+    def run(self, context: RepositoryContext, state: SharedState) -> AgentResult:
+        aggregate = AgentResult()
+        for child in self.children:
+            aggregate.extend(child.execute(context, state))
+        return aggregate

--- a/multi_agent_review/agents/cartographer.py
+++ b/multi_agent_review/agents/cartographer.py
@@ -1,0 +1,118 @@
+"""Repository cartographer agent."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, List
+
+from ..models import AgentResult, ComponentMap
+from ..repository import RepositoryContext
+from .base import BaseAgent
+
+
+class RepositoryCartographerAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Repository Cartographer",
+            description="Builds a component map of routes, services, SQL tables, and frontend endpoints.",
+        )
+
+    def run(self, context: RepositoryContext, state) -> AgentResult:
+        result = AgentResult()
+        map_data: ComponentMap = {}
+
+        backend_routes = []
+        for mount in context.backend_route_mounts():
+            route_path = Path(context.root / mount["file_path"])
+            endpoints = context.parse_route_endpoints(route_path, mount["base_path"])
+            backend_routes.append(
+                {
+                    "identifier": mount["identifier"],
+                    "base_path": mount["base_path"],
+                    "file_path": mount["file_path"],
+                    "endpoint_count": len(endpoints),
+                    "endpoints": endpoints,
+                }
+            )
+        map_data["backend_routes"] = backend_routes
+
+        services = []
+        for service_file in context.iter_backend_service_files():
+            services.append(str(service_file.relative_to(context.root)))
+        map_data["backend_services"] = services
+
+        frontend_endpoints = self._parse_frontend_api_client(context)
+        if frontend_endpoints:
+            map_data["frontend_endpoints"] = frontend_endpoints
+
+        database_tables = self._parse_database_tables(context)
+        if database_tables:
+            map_data["database_tables"] = database_tables
+
+        result.artifacts["component_map"] = map_data
+
+        result.findings.append(
+            self.finding(
+                title="Component map generated",
+                description=(
+                    "Indexed "
+                    f"{len(backend_routes)} Express router modules, "
+                    f"{len(services)} services, "
+                    f"{len(database_tables)} SQL tables, and "
+                    f"{len(frontend_endpoints)} frontend API endpoints for downstream agents."
+                ),
+                severity="info",
+            )
+        )
+        return result
+
+    def _parse_frontend_api_client(self, context: RepositoryContext) -> List[Dict[str, object]]:
+        api_file = context.frontend_path / "src" / "lib" / "api.ts"
+        content = context.maybe_read_text(api_file)
+        if not content:
+            return []
+
+        endpoints: List[Dict[str, object]] = []
+        for line_no, line in enumerate(content.splitlines(), 1):
+            match = re.search(r"this\.client\.(get|post|put|delete)\(([^,]+)", line)
+            if not match:
+                continue
+            method = match.group(1).upper()
+            raw_arg = match.group(2).strip()
+            if not raw_arg or raw_arg[0] not in ("'", '"', '`'):
+                continue
+            delimiter = raw_arg[0]
+            closing = raw_arg.find(delimiter, 1)
+            if closing == -1:
+                continue
+            raw_path = raw_arg[1:closing]
+            normalized = RepositoryContext._normalize_path(raw_path)
+            endpoints.append(
+                {
+                    "method": method,
+                    "path": normalized,
+                    "line": line_no,
+                    "file_path": str(api_file.relative_to(context.root)),
+                }
+            )
+        return endpoints
+
+    def _parse_database_tables(self, context: RepositoryContext) -> List[Dict[str, object]]:
+        tables: List[Dict[str, object]] = []
+        create_table_pattern = re.compile(
+            r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>[A-Za-z0-9_]+)",
+            re.IGNORECASE,
+        )
+        for sql_file in context.iter_sql_files():
+            content = context.read_text(sql_file)
+            for match in create_table_pattern.finditer(content):
+                line = content.count("\n", 0, match.start()) + 1
+                tables.append(
+                    {
+                        "name": match.group("name"),
+                        "file_path": str(sql_file.relative_to(context.root)),
+                        "line": line,
+                    }
+                )
+        return tables

--- a/multi_agent_review/agents/database.py
+++ b/multi_agent_review/agents/database.py
@@ -1,0 +1,69 @@
+"""Database integrity agent."""
+
+from __future__ import annotations
+
+import re
+from ..models import AgentResult
+from ..repository import RepositoryContext
+from .base import BaseAgent
+
+
+class DatabaseIntegrityAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Database Integrity",
+            description="Checks schema definitions for missing constraints and lingering seed data.",
+        )
+
+    def run(self, context: RepositoryContext, state) -> AgentResult:
+        result = AgentResult()
+        init_sql = context.database_path / "init.sql"
+        content = context.maybe_read_text(init_sql)
+        if not content:
+            return result
+
+        table_blocks = list(self._iter_table_blocks(content))
+        for name, block_start, block_text in table_blocks:
+            if name == "user_sessions" and "REFERENCES" not in block_text:
+                line = content.count("\n", 0, block_start) + 1
+                result.findings.append(
+                    self.finding(
+                        title="user_sessions table lacks foreign key constraint",
+                        description=(
+                            "Connect `user_id` to the appropriate patients/providers table with a foreign key to enforce referential "
+                            "integrity for session revocation."
+                        ),
+                        severity="medium",
+                        file_path=str(init_sql.relative_to(context.root)),
+                        line=line,
+                        tags=["database", "integrity"],
+                    )
+                )
+
+        for match in re.finditer(r"INSERT INTO\s+patients", content, re.IGNORECASE):
+            line = content.count("\n", 0, match.start()) + 1
+            result.findings.append(
+                self.finding(
+                    title="Seed patient records included in init.sql",
+                    description="Remove hard-coded sample patients before production to avoid leaking test identities.",
+                    severity="low",
+                    file_path=str(init_sql.relative_to(context.root)),
+                    line=line,
+                    tags=["database", "seed"],
+                )
+            )
+
+        return result
+
+    def _iter_table_blocks(self, content: str):
+        pattern = re.compile(r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>[A-Za-z0-9_]+)\s*\(", re.IGNORECASE)
+        for match in pattern.finditer(content):
+            name = match.group("name")
+            start = match.start()
+            end = content.find("\n);", match.end())
+            if end == -1:
+                end = content.find(");", match.end())
+            if end == -1:
+                continue
+            block_text = content[match.end():end]
+            yield name, start, block_text

--- a/multi_agent_review/agents/frontend.py
+++ b/multi_agent_review/agents/frontend.py
@@ -1,0 +1,66 @@
+"""Frontend experience agent."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from ..models import AgentResult
+from ..repository import RepositoryContext
+from .base import BaseAgent
+
+
+class FrontendExperienceAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Frontend Experience",
+            description="Examines Next.js screens for mock data and missing API integrations.",
+        )
+
+    def run(self, context: RepositoryContext, state) -> AgentResult:
+        result = AgentResult()
+        for page in context.iter_frontend_page_files():
+            content = context.read_text(page)
+            rel_path = str(page.relative_to(context.root))
+            for line in self._find_mock_usage(content):
+                result.findings.append(
+                    self.finding(
+                        title="Mock data still powering portal UI",
+                        description="Replace mock collections with API calls wired through `apiClient` to surface real patient data.",
+                        severity="medium",
+                        file_path=rel_path,
+                        line=line,
+                        tags=["frontend", "mock"],
+                    )
+                )
+
+            for line in self._find_todo_comments(content):
+                result.findings.append(
+                    self.finding(
+                        title="TODO left in UI flow",
+                        description="Resolve TODOs to finalize the patient/provider experience before release.",
+                        severity="low",
+                        file_path=rel_path,
+                        line=line,
+                        tags=["frontend", "todo"],
+                    )
+                )
+        return result
+
+    def _find_mock_usage(self, content: str) -> Iterable[int]:
+        seen_lines = []
+        for match in re.finditer(r"mock[A-Za-z0-9_]*", content):
+            line = content.count('\n', 0, match.start()) + 1
+            if line not in seen_lines:
+                seen_lines.append(line)
+                yield line
+            if len(seen_lines) >= 5:
+                break
+
+    def _find_todo_comments(self, content: str) -> Iterable[int]:
+        yielded = 0
+        for match in re.finditer(r"TODO", content, re.IGNORECASE):
+            yield content.count('\n', 0, match.start()) + 1
+            yielded += 1
+            if yielded >= 3:
+                break

--- a/multi_agent_review/agents/integration.py
+++ b/multi_agent_review/agents/integration.py
@@ -1,0 +1,83 @@
+"""Integration contract agent."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Set, Tuple
+
+from ..models import AgentResult, ComponentMap, SharedState
+from .base import BaseAgent
+
+
+class IntegrationContractAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Integration Contract",
+            description="Cross-checks frontend API client calls against Express routes.",
+        )
+
+    def run(self, context, state: SharedState) -> AgentResult:
+        result = AgentResult()
+        component_map: ComponentMap = state.get_artifact("Repository Cartographer", "component_map", {})
+        backend_routes = component_map.get("backend_routes", [])
+        frontend_endpoints = component_map.get("frontend_endpoints", [])
+
+        backend_set: Set[Tuple[str, str]] = set()
+        backend_index: Dict[Tuple[str, str], Dict[str, object]] = {}
+        for route in backend_routes:
+            for endpoint in route.get("endpoints", []):
+                key = (endpoint["method"], endpoint["full_path"])
+                backend_set.add(key)
+                backend_index[key] = {
+                    "file_path": route["file_path"],
+                    "line": endpoint["line"],
+                }
+
+        frontend_set: Set[Tuple[str, str]] = set()
+        frontend_index: Dict[Tuple[str, str], Dict[str, object]] = {}
+        for endpoint in frontend_endpoints:
+            key = (endpoint["method"], endpoint["path"])
+            frontend_set.add(key)
+            frontend_index[key] = endpoint
+
+        missing_in_frontend = sorted(backend_set - frontend_set)[:12]
+        for method, path in missing_in_frontend:
+            info = backend_index[(method, path)]
+            result.findings.append(
+                self.finding(
+                    title="Backend endpoint missing from API client",
+                    description=(
+                        f"Expose `{method} {path}` through the Next.js api client to keep the portal in sync with the Express app."
+                    ),
+                    severity="medium",
+                    file_path=info["file_path"],
+                    line=info["line"],
+                    tags=["integration"],
+                )
+            )
+
+        extra_in_frontend = sorted(frontend_set - backend_set)[:12]
+        for method, path in extra_in_frontend:
+            info = frontend_index[(method, path)]
+            result.findings.append(
+                self.finding(
+                    title="Frontend references undefined API route",
+                    description=(
+                        f"The client calls `{method} {path}` but no Express route exposes it. Either implement the route or update the UI."
+                    ),
+                    severity="high",
+                    file_path=info["file_path"],
+                    line=info["line"],
+                    tags=["integration"],
+                )
+            )
+
+        if not missing_in_frontend and not extra_in_frontend:
+            result.findings.append(
+                self.finding(
+                    title="Frontend and backend API contracts aligned",
+                    description="API client paths mirror Express routes.",
+                    severity="info",
+                )
+            )
+
+        return result

--- a/multi_agent_review/agents/security.py
+++ b/multi_agent_review/agents/security.py
@@ -1,0 +1,81 @@
+"""Security and compliance review agent."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..models import AgentResult
+from ..repository import RepositoryContext
+from .base import BaseAgent
+
+
+class SecurityComplianceAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Security & Compliance",
+            description="Audits middleware and webhook handlers for missing protections.",
+        )
+
+    def run(self, context: RepositoryContext, state) -> AgentResult:
+        result = AgentResult()
+        for mount in context.backend_route_mounts():
+            content = context.read_text(Path(context.root / mount["file_path"]))
+
+            for line in self._detect_raw_body_parsing_issue(content):
+                result.findings.append(
+                    self.finding(
+                        title="Raw webhook payload parsed without Buffer conversion",
+                        description=(
+                            "The handler uses `express.raw` but parses `req.body` without converting the Buffer to a string. "
+                            "Call `JSON.parse(req.body.toString())` to avoid runtime crashes."
+                        ),
+                        severity="high",
+                        file_path=mount["file_path"],
+                        line=line,
+                        tags=["security", "webhook"],
+                    )
+                )
+
+            line = self._detect_missing_signature_verification(content)
+            if line:
+                result.findings.append(
+                    self.finding(
+                        title="Webhook signature captured but never validated",
+                        description=(
+                            "The SendGrid webhook stores the `signature` header yet never verifies it. "
+                            "Use the official verification helper to prevent forged requests."
+                        ),
+                        severity="medium",
+                        file_path=mount["file_path"],
+                        line=line,
+                        tags=["security", "webhook"],
+                    )
+                )
+
+        return result
+
+    def _detect_raw_body_parsing_issue(self, content: str):
+        lines = []
+        if "express.raw" not in content:
+            return lines
+        for match in re.finditer(r"JSON\.parse\(req\.body\)", content):
+            line = content.count("\n", 0, match.start()) + 1
+            lines.append(line)
+        return lines
+
+    def _detect_missing_signature_verification(self, content: str):
+        if "sendgrid" not in content.lower():
+            return 0
+        marker = "Verify webhook signature"
+        idx = content.find(marker)
+        if idx == -1:
+            return 0
+        after = content[idx: idx + 200]
+        if "TODO" in after or "optional" in after.lower():
+            line = content.count("\n", 0, idx) + 1
+            return line
+        if "signature" in after and "verify" not in content[idx: idx + 500].lower():
+            line = content.count("\n", 0, idx) + 1
+            return line
+        return 0

--- a/multi_agent_review/agents/synthesis.py
+++ b/multi_agent_review/agents/synthesis.py
@@ -1,0 +1,58 @@
+"""Synthesis agent to assemble the final report."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Dict, List
+
+from ..models import AgentResult, Finding, SharedState
+from .base import BaseAgent
+
+
+class SynthesisAgent(BaseAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            name="Synthesis Reporter",
+            description="Aggregates findings into a markdown report.",
+        )
+
+    def run(self, context, state: SharedState) -> AgentResult:
+        findings = list(state.all_findings())
+        if not findings:
+            report = "# Review Report\n\nNo findings recorded."
+        else:
+            report = self._build_report(findings, state)
+
+        result = AgentResult()
+        result.artifacts["report"] = report
+        return result
+
+    def _build_report(self, findings: List[Finding], state: SharedState) -> str:
+        severity_counts = Counter(f.severity for f in findings)
+        by_agent: Dict[str, List[Finding]] = defaultdict(list)
+        for finding in findings:
+            by_agent[finding.agent].append(finding)
+
+        lines = ["# Multi-agent Review Report", ""]
+        lines.append("## Summary")
+        lines.append(
+            " | ".join(f"{severity.title()}: {count}" for severity, count in severity_counts.items()) or "No findings"
+        )
+        lines.append("")
+
+        automation = state.get_artifact("Automation & Quality", "commands")
+        if automation:
+            lines.append("### Automation Commands")
+            for workspace, cmds in automation.items():
+                if cmds:
+                    lines.append(f"- **{workspace.title()}**: {', '.join(cmds)}")
+            lines.append("")
+
+        lines.append("## Findings by Agent")
+        for agent_name, agent_findings in sorted(by_agent.items()):
+            lines.append(f"### {agent_name}")
+            for finding in agent_findings:
+                lines.append(finding.to_markdown())
+            lines.append("")
+
+        return "\n".join(lines)

--- a/multi_agent_review/cli.py
+++ b/multi_agent_review/cli.py
@@ -1,0 +1,49 @@
+"""Command line interface for running the review orchestrator."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .orchestrator import ReviewOrchestrator
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the multi-agent review workflow")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to the repository root (defaults to current working directory)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the markdown report",
+    )
+    parser.add_argument(
+        "--list-agents",
+        action="store_true",
+        help="List configured agents and exit",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    orchestrator = ReviewOrchestrator(args.root)
+
+    if args.list_agents:
+        for name in orchestrator.agent_names():
+            print(name)
+        return
+
+    report, _state = orchestrator.run()
+    print(report)
+
+    if args.output:
+        args.output.write_text(report, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/multi_agent_review/models.py
+++ b/multi_agent_review/models.py
@@ -1,0 +1,114 @@
+"""Shared data models for the review automation toolkit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, TypedDict
+
+Severity = str  # using string severities for flexibility
+
+
+@dataclass
+class Finding:
+    """Structured improvement or risk surfaced by an agent."""
+
+    agent: str
+    title: str
+    description: str
+    severity: Severity = "info"
+    file_path: Optional[str] = None
+    line: Optional[int] = None
+    tags: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "agent": self.agent,
+            "title": self.title,
+            "description": self.description,
+            "severity": self.severity,
+            "tags": list(self.tags),
+        }
+        if self.file_path:
+            payload["file_path"] = self.file_path
+        if self.line is not None:
+            payload["line"] = self.line
+        return payload
+
+    def to_markdown(self) -> str:
+        location = ""
+        if self.file_path:
+            location = f" (`{self.file_path}`"
+            if self.line is not None:
+                location += f":{self.line}"
+            location += ")"
+        tag_str = f" [{' '.join(f'#{tag}' for tag in self.tags)}]" if self.tags else ""
+        return f"- **{self.severity.upper()}** {self.title}{location}{tag_str}\n  - {self.description}"
+
+
+@dataclass
+class AgentResult:
+    """Container for an agent's outcome."""
+
+    findings: List[Finding] = field(default_factory=list)
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    notes: Optional[str] = None
+
+    def extend(self, other: "AgentResult") -> None:
+        self.findings.extend(other.findings)
+        self.artifacts.update(other.artifacts)
+        if other.notes:
+            if self.notes:
+                self.notes += f"\n{other.notes}"
+            else:
+                self.notes = other.notes
+
+
+@dataclass
+class SharedState:
+    """State object shared across agents."""
+
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    findings: List[Finding] = field(default_factory=list)
+
+    def record(self, agent: str, result: AgentResult) -> None:
+        self.findings.extend(result.findings)
+        for key, value in result.artifacts.items():
+            self.artifacts[f"{agent}:{key}"] = value
+
+    def get_artifact(self, agent: str, key: str, default: Any = None) -> Any:
+        return self.artifacts.get(f"{agent}:{key}", default)
+
+    def all_findings(self) -> Sequence[Finding]:
+        return tuple(self.findings)
+
+
+class RouteMount(TypedDict):
+    identifier: str
+    base_path: str
+    file_path: str
+
+
+class RouteEndpoint(TypedDict):
+    method: str
+    path: str
+    full_path: str
+    line: int
+    requires_auth: bool
+
+
+class ComponentMap(TypedDict, total=False):
+    backend_routes: List[Dict[str, Any]]
+    backend_services: List[str]
+    frontend_endpoints: List[Dict[str, Any]]
+    database_tables: List[Dict[str, Any]]
+
+
+def combine_artifacts(state: SharedState, keys: Iterable[Tuple[str, str]]) -> Dict[str, Any]:
+    """Utility to combine artifacts from multiple agents."""
+
+    output: Dict[str, Any] = {}
+    for agent, key in keys:
+        composite_key = f"{agent}:{key}"
+        if composite_key in state.artifacts:
+            output[key] = state.artifacts[composite_key]
+    return output

--- a/multi_agent_review/orchestrator.py
+++ b/multi_agent_review/orchestrator.py
@@ -1,0 +1,53 @@
+"""Orchestrator coordinating the review agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence
+
+from .agents import (
+    AIConsultationAgent,
+    AutomationQualityAgent,
+    BackendReviewAgent,
+    DatabaseIntegrityAgent,
+    FrontendExperienceAgent,
+    IntegrationContractAgent,
+    RepositoryCartographerAgent,
+    SecurityComplianceAgent,
+    SynthesisAgent,
+)
+from .agents.base import BaseAgent
+from .models import SharedState
+from .repository import RepositoryContext
+
+
+class ReviewOrchestrator:
+    """Coordinates the multi-agent review workflow."""
+
+    def __init__(self, root: Path, agents: Sequence[BaseAgent] | None = None) -> None:
+        self.root = Path(root)
+        self.context = RepositoryContext(self.root)
+        self.agents: List[BaseAgent] = list(agents) if agents else self._default_agents()
+
+    def _default_agents(self) -> List[BaseAgent]:
+        return [
+            RepositoryCartographerAgent(),
+            BackendReviewAgent(),
+            SecurityComplianceAgent(),
+            AIConsultationAgent(),
+            DatabaseIntegrityAgent(),
+            FrontendExperienceAgent(),
+            IntegrationContractAgent(),
+            AutomationQualityAgent(),
+            SynthesisAgent(),
+        ]
+
+    def run(self) -> tuple[str, SharedState]:
+        state = SharedState()
+        for agent in self.agents:
+            agent.execute(self.context, state)
+        report = state.get_artifact("Synthesis Reporter", "report", "")
+        return report, state
+
+    def agent_names(self) -> List[str]:
+        return [agent.name for agent in self.agents]

--- a/multi_agent_review/repository.py
+++ b/multi_agent_review/repository.py
@@ -1,0 +1,161 @@
+"""Repository indexing utilities used by the review agents."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .models import RouteEndpoint, RouteMount
+
+
+@dataclass
+class RepositoryContext:
+    """Indexed view over the telehealth repository."""
+
+    root: Path
+    backend_path: Path = field(init=False)
+    backend_src: Path = field(init=False)
+    frontend_path: Path = field(init=False)
+    database_path: Path = field(init=False)
+    _cache: Dict[Path, str] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        self.root = self.root.resolve()
+        self.backend_path = (self.root / "backend").resolve()
+        self.backend_src = (self.backend_path / "src").resolve()
+        self.frontend_path = (self.root / "frontend").resolve()
+        self.database_path = (self.root / "database").resolve()
+
+    def exists(self) -> bool:
+        return self.root.exists()
+
+    def read_text(self, path: Path) -> str:
+        absolute = path if path.is_absolute() else (self.root / path)
+        absolute = absolute.resolve()
+        if absolute not in self._cache:
+            self._cache[absolute] = absolute.read_text(encoding="utf-8")
+        return self._cache[absolute]
+
+    def maybe_read_text(self, path: Path) -> Optional[str]:
+        try:
+            return self.read_text(path)
+        except FileNotFoundError:
+            return None
+
+    def read_json(self, path: Path) -> Dict:
+        content = self.read_text(path)
+        return json.loads(content)
+
+    @property
+    def backend_routes_dir(self) -> Path:
+        return self.backend_src / "routes"
+
+    @property
+    def backend_services_dir(self) -> Path:
+        return self.backend_src / "services"
+
+    def iter_backend_route_files(self) -> Iterable[Path]:
+        if not self.backend_routes_dir.exists():
+            return []
+        return sorted(self.backend_routes_dir.glob("*.js"))
+
+    def iter_backend_service_files(self) -> Iterable[Path]:
+        if not self.backend_services_dir.exists():
+            return []
+        return sorted(self.backend_services_dir.glob("*.js"))
+
+    def iter_frontend_page_files(self) -> Iterable[Path]:
+        if not self.frontend_path.exists():
+            return []
+        app_dir = self.frontend_path / "src" / "app"
+        return sorted(app_dir.rglob("page.tsx")) if app_dir.exists() else []
+
+    def iter_frontend_component_files(self) -> Iterable[Path]:
+        if not self.frontend_path.exists():
+            return []
+        comp_dir = self.frontend_path / "src" / "components"
+        return sorted(comp_dir.glob("*.tsx")) if comp_dir.exists() else []
+
+    def iter_sql_files(self) -> Iterable[Path]:
+        if not self.database_path.exists():
+            return []
+        return sorted(self.database_path.glob("*.sql"))
+
+    def backend_route_mounts(self) -> List[RouteMount]:
+        app_file = self.backend_src / "app.js"
+        if not app_file.exists():
+            return []
+        content = self.read_text(app_file)
+
+        import_pattern = re.compile(
+            r"import\s+(?P<identifier>[A-Za-z0-9_]+)\s+from\s+['\"]\.\/routes\/(?P<file>[^'\"]+)['\"];"
+        )
+        use_pattern = re.compile(
+            r"app\.use\(\s*['\"](?P<mount>[^'\"]+)['\"],\s*(?P<identifier>[A-Za-z0-9_]+)\s*\)"
+        )
+
+        identifier_to_file: Dict[str, str] = {}
+        for match in import_pattern.finditer(content):
+            identifier_to_file[match.group("identifier")] = match.group("file")
+
+        mounts: List[RouteMount] = []
+        for match in use_pattern.finditer(content):
+            identifier = match.group("identifier")
+            base_path = match.group("mount")
+            file_name = identifier_to_file.get(identifier)
+            if not file_name:
+                continue
+            if not file_name.endswith(".js"):
+                file_name = f"{file_name}.js"
+            route_file = (self.backend_routes_dir / file_name).resolve()
+            mounts.append(
+                {
+                    "identifier": identifier,
+                    "base_path": base_path,
+                    "file_path": str(route_file.relative_to(self.root)),
+                }
+            )
+        return mounts
+
+    def parse_route_endpoints(self, route_path: Path, base_path: str) -> List[RouteEndpoint]:
+        content = self.read_text(route_path)
+        pattern = re.compile(
+            r"router\.(get|post|put|delete|patch)\(\s*(?:['\"](?P<path>[^'\"]+)['\"]|`(?P<tpath>[^`]+)`)",
+            re.IGNORECASE,
+        )
+        endpoints: List[RouteEndpoint] = []
+        for match in pattern.finditer(content):
+            method = match.group(1).upper()
+            path_literal = match.group("path") or match.group("tpath") or ""
+            normalized_path = self._normalize_path(path_literal)
+            full_path = self._join_paths(base_path, normalized_path)
+            line = content.count("\n", 0, match.start()) + 1
+            requires_auth = "requireAuth" in content or "requireRole" in content or "optionalAuth" in content
+            endpoints.append(
+                {
+                    "method": method,
+                    "path": normalized_path,
+                    "full_path": full_path,
+                    "line": line,
+                    "requires_auth": requires_auth,
+                }
+            )
+        return endpoints
+
+    @staticmethod
+    def _join_paths(base: str, path: str) -> str:
+        if path == "/":
+            return base
+        if path.startswith("/"):
+            return base.rstrip("/") + path
+        return f"{base.rstrip('/')}/{path}"
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        # Convert template literals like `/foo/${id}` into `/foo/:id`
+        if "${" in path:
+            return re.sub(r"\$\{([^}]+)\}", lambda m: f":{m.group(1)}", path)
+        return path

--- a/review-report.md
+++ b/review-report.md
@@ -1,0 +1,159 @@
+# Multi-agent Review Report
+
+## Summary
+Info: 3 | High: 18 | Medium: 44 | Low: 2
+
+### Automation Commands
+- **Backend**: npm run lint, npm run test
+- **Frontend**: npm run lint, npm run test, npm run type-check
+
+## Findings by Agent
+### AI Consultation Specialist
+- **MEDIUM** LLM JSON output is trusted without schema validation (`backend/src/services/ai-consultation.service.js`:72) [#ai #safety]
+  - Wrap the parsed response in a schema validator (zod/io-ts) to reject malformed content before persisting clinical recommendations.
+- **MEDIUM** Patient messaging prompt lacks compliance disclaimer (`backend/src/services/ai-consultation.service.js`:94) [#ai #compliance]
+  - Add explicit instructions for medical disclaimers and clinician review when generating patient-facing messages so AI output never replaces licensed guidance.
+
+### Automation & Quality
+- **INFO** Backend automation commands discovered (`backend/package.json`) [#automation]
+  - npm run lint, npm run test
+- **INFO** Frontend automation commands discovered (`frontend/package.json`) [#automation]
+  - npm run lint, npm run test, npm run type-check
+
+### Backend API Reviewer
+- **HIGH** Route missing authentication guard (`backend/src/routes/messages.js`) [#auth #backend]
+  - The router mounted at `/api/messages` does not reference `requireAuth` or `requireRole`. Attach role-aware middleware so protected resources cannot be accessed anonymously.
+- **HIGH** Route missing authentication guard (`backend/src/routes/provider-consultations.js`) [#auth #backend]
+  - The router mounted at `/api/provider/consultations` does not reference `requireAuth` or `requireRole`. Attach role-aware middleware so protected resources cannot be accessed anonymously.
+- **HIGH** Route missing authentication guard (`backend/src/routes/orders.js`) [#auth #backend]
+  - The router mounted at `/api/orders` does not reference `requireAuth` or `requireRole`. Attach role-aware middleware so protected resources cannot be accessed anonymously.
+- **HIGH** Route missing authentication guard (`backend/src/routes/files.js`) [#auth #backend]
+  - The router mounted at `/api/files` does not reference `requireAuth` or `requireRole`. Attach role-aware middleware so protected resources cannot be accessed anonymously.
+- **MEDIUM** Placeholder implementation in API route (`backend/src/routes/files.js`:12) [#todo #backend]
+  - Replace the placeholder response with production logic for file uploads and retrieval.
+- **MEDIUM** Placeholder implementation in API route (`backend/src/routes/files.js`:22) [#todo #backend]
+  - Replace the placeholder response with production logic for file uploads and retrieval.
+- **HIGH** Route missing authentication guard (`backend/src/routes/treatment-plans.js`) [#auth #backend]
+  - The router mounted at `/api/treatment-plans` does not reference `requireAuth` or `requireRole`. Attach role-aware middleware so protected resources cannot be accessed anonymously.
+
+### Database Integrity
+- **MEDIUM** user_sessions table lacks foreign key constraint (`database/init.sql`:99) [#database #integrity]
+  - Connect `user_id` to the appropriate patients/providers table with a foreign key to enforce referential integrity for session revocation.
+- **LOW** Seed patient records included in init.sql (`database/init.sql`:139) [#database #seed]
+  - Remove hard-coded sample patients before production to avoid leaking test identities.
+
+### Frontend Experience
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/patient/dashboard/page.tsx`:20) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/patient/dashboard/page.tsx`:52) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/patient/dashboard/page.tsx`:76) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/patient/dashboard/page.tsx`:85) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/patient/dashboard/page.tsx`:107) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **LOW** TODO left in UI flow (`frontend/src/app/patient/health-quiz/page.tsx`:296) [#frontend #todo]
+  - Resolve TODOs to finalize the patient/provider experience before release.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/patient/messages/page.tsx`:69) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/patient/messages/page.tsx`:98) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/checkin/[id]/page.tsx`:102) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/checkin/[id]/page.tsx`:171) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/consultation/[id]/page.tsx`:77) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/consultation/[id]/page.tsx`:111) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/consultation/[id]/page.tsx`:115) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/consultation/[id]/page.tsx`:116) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/consultation/[id]/page.tsx`:117) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/consultations/page.tsx`:47) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/consultations/page.tsx`:104) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/messages/page.tsx`:46) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/messages/page.tsx`:82) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/orders/page.tsx`:71) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/orders/page.tsx`:158) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/patients/page.tsx`:50) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/patients/page.tsx`:134) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/plans/page.tsx`:72) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/plans/page.tsx`:235) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/providers/page.tsx`:60) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+- **MEDIUM** Mock data still powering portal UI (`frontend/src/app/portal/providers/page.tsx`:123) [#frontend #mock]
+  - Replace mock collections with API calls wired through `apiClient` to surface real patient data.
+
+### Integration Contract
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin.js`:351) [#integration]
+  - Expose `GET /api/admin/analytics/summary` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin.js`:52) [#integration]
+  - Expose `GET /api/admin/consultations/pending` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin.js`:24) [#integration]
+  - Expose `GET /api/admin/metrics` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin.js`:225) [#integration]
+  - Expose `GET /api/admin/orders/stats` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin.js`:121) [#integration]
+  - Expose `GET /api/admin/patients` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin-patients.js`:24) [#integration]
+  - Expose `GET /api/admin/patients/:id/full` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin-patients.js`:506) [#integration]
+  - Expose `GET /api/admin/patients/:id/statistics` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/admin.js`:177) [#integration]
+  - Expose `GET /api/admin/providers` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/ai-consultation.js`:144) [#integration]
+  - Expose `GET /api/ai-consultation/status` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/auth.js`:634) [#integration]
+  - Expose `GET /api/auth/me` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/auth.js`:608) [#integration]
+  - Expose `GET /api/auth/verify-email/:token` through the Next.js api client to keep the portal in sync with the Express app.
+- **MEDIUM** Backend endpoint missing from API client (`backend/src/routes/consultations.js`:215) [#integration]
+  - Expose `GET /api/consultations` through the Next.js api client to keep the portal in sync with the Express app.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:116) [#integration]
+  - The client calls `GET /api/admin/audit-logs` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:115) [#integration]
+  - The client calls `GET /api/admin/dashboard` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:60) [#integration]
+  - The client calls `GET /api/auth/profile` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:70) [#integration]
+  - The client calls `GET /api/consultations/patient/:patientId` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:72) [#integration]
+  - The client calls `GET /api/consultations/provider/queue` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:108) [#integration]
+  - The client calls `GET /api/files/:id/download` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:86) [#integration]
+  - The client calls `GET /api/messages/unread-count` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:93) [#integration]
+  - The client calls `GET /api/patients/:id/consultations` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:98) [#integration]
+  - The client calls `GET /api/providers` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:99) [#integration]
+  - The client calls `GET /api/providers/:id` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:100) [#integration]
+  - The client calls `GET /api/providers/:id/consultations` but no Express route exposes it. Either implement the route or update the UI.
+- **HIGH** Frontend references undefined API route (`frontend/src/lib/api.ts`:59) [#integration]
+  - The client calls `POST /api/auth/login` but no Express route exposes it. Either implement the route or update the UI.
+
+### Repository Cartographer
+- **INFO** Component map generated
+  - Indexed 15 Express router modules, 7 services, 33 SQL tables, and 23 frontend API endpoints for downstream agents.
+
+### Security & Compliance
+- **HIGH** Raw webhook payload parsed without Buffer conversion (`backend/src/routes/webhooks.js`:16) [#security #webhook]
+  - The handler uses `express.raw` but parses `req.body` without converting the Buffer to a string. Call `JSON.parse(req.body.toString())` to avoid runtime crashes.
+- **MEDIUM** Webhook signature captured but never validated (`backend/src/routes/webhooks.js`:11) [#security #webhook]
+  - The SendGrid webhook stores the `signature` header yet never verifies it. Use the official verification helper to prevent forged requests.


### PR DESCRIPTION
## Summary
- add a Python-based multi-agent review orchestrator with reusable data models, repository indexer, and specialist agents
- expose a CLI for running the review workflow and document usage in the README
- generate an example review report that captures current findings across backend, frontend, database, and automation domains

## Testing
- python -m multi_agent_review.cli --list-agents
- python -m multi_agent_review.cli --root . --output review-report.md

------
https://chatgpt.com/codex/tasks/task_e_68c9e942649c8326b50ffc2195eb3da2